### PR TITLE
Use getTitle() for facebooklike dialog heading

### DIFF
--- a/src/js/services/facebooklike.js
+++ b/src/js/services/facebooklike.js
@@ -2,7 +2,7 @@
 
 module.exports = function(shariff) {
   var url = shariff.getURL()
-  var dialogTitle = shariff.getMeta('og:title') || document.title
+  var dialogTitle = shariff.getTitle()
   var shariffLang = shariff.getOption('lang')
   var dialogLocale = 'en_GB'
   var dialogClose = 'Close'


### PR DESCRIPTION
Use shariff.getTitle() for facebooklike dialog heading so a data-title
parameter would be used, if given. This is necessary if the page to be
liked (data-url) is not equal to the current page.