### PR TITLE
Add new project homepage for Shariff-Plus

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -92,7 +92,7 @@ $ npm run dev
 | `data-facebooklike-options` | Objekt mit Optionen für den Button "Gefällt mir" von Facebook, wie sie der Facebook Konfigurator für den Button liefert. Für die Verwendung im `data`-Attribut muss die Angabe Entity-enkodiert werden. Beispiel mit den Standardwerten von Facebook: `data-facebooklike-options="{&quot;width&quot;:450,&quot;layout&quot;:&quot;standard&quot;,&quot;action&quot;:&quot;like&quot;,&quot;size&quot;:&quot;large&quot;,&quot;show_faces&quot;:true,&quot;share&quot;:true,&quot;appId&quot;:&quot;99999&quot;}"` mit 99999 = Facebook `app_id`. | Siehe Beispiel, mit appId = Wert des Meta-Tags `fb:app_id` oder `null`, wenn nicht definiert. |
 | `data-flattr-category` | Kategorie für Flattr-Spende. | `null` |
 | `data-flattr-user` | Benutzer, der die Flattr-Spende erhält. | `null` |
-| `data-info-url` | URL der Infoseite. | `http://ct.de/-2467514` |
+| `data-info-url` | URL der Infoseite. | `https://www.richard-fath.de/en/software/shariff-plus.html` |
 | `data-info-display` | Wie die Infoseite angezeigt wird. Werte: `blank`, `popup`, `self`. | `blank` |
 | `data-lang`      | Lokalisierung auswählen. Verfügbar: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Body verwendet. Der Mail-Body-Text sollte den Platzhalter `{url}` enthalten. Dieser wird durch die zu teilende URL ersetzt. | siehe `data-url` |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Shariff-Plus – Social Media Buttons With Privacy [![Build Status](https://travis-ci.org/richard67/shariff-plus.svg?branch=master)](https://travis-ci.org/richard67/shariff-plus)
 
-
 Shariff-Plus enables website users to share and like their favorite content without compromising their privacy. [Demo](https://www.richard-fath.de/shariff-plus-demo/index.html)
 
 It is equal to [Shariff by Heise Medien](https://github.com/heiseonline/shariff) plus extensions like showing the Facebook "Like" button in a dialog, which is not intended to be ever included into Shariff, or other enhancements or corrections which have not been integrated into Shariff (yet).
@@ -93,7 +92,7 @@ $ npm run dev
 | `data-facebooklike-options` | An entity-encoded JSON string containing an object with options for the Facebook "Like" button as provided by the Facebook configurator for that button. Example with default values of Facebook: `data-facebooklike-options="{&quot;width&quot;:450,&quot;layout&quot;:&quot;standard&quot;,&quot;action&quot;:&quot;like&quot;,&quot;size&quot;:&quot;large&quot;,&quot;show_faces&quot;:true,&quot;share&quot;:true,&quot;appId&quot;:&quot;99999&quot;}"` with 99999 = Facebook `app_id`. | See example, with appId = value of the `fb:app_id` meta tag or `null` if not defined. |
 | `data-flattr-category` | Category to be used for Flattr. | `null` |
 | `data-flattr-user` | User that receives Flattr donation. | `null` |
-| `data-info-url` | URL of the info page. | `http://ct.de/-2467514` |
+| `data-info-url` | URL of the info page. | `https://www.richard-fath.de/en/software/shariff-plus.html` |
 | `data-info-display` | How to display the info page. Values: `blank`, `popup`, `self`. | `blank` |
 | `data-lang`      | The localisation to use. Available: `bg`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail body. The body text should contain the placeholder `{url}` which will be replaced with the share URL. | see `data-url`  |

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "shariff-plus",
-  "homepage": "https://github.com/richard67/shariff-plus",
+  "homepage": "https://www.richard-fath.de/en/software/shariff-plus.html",
   "authors": [
     "Richard Fath (shariff-plus) <richard@richard-fath.de>",
     "Ines Pauer (shariff) <ipa@heise.de>",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "publishConfig": {
     "registry": "http://registry.npmjs.org"
   },
-  "homepage": "https://github.com/richard67/shariff-plus",
+  "homepage": "https://www.richard-fath.de/en/software/shariff-plus.html",
   "devDependencies": {
     "autoprefixer": "^7.1.6",
     "babel-core": "^6.26.0",

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -20,7 +20,7 @@ const Defaults = {
   backendUrl: null,
 
   // Link to the "about" page
-  infoUrl: 'http://ct.de/-2467514',
+  infoUrl: 'https://www.richard-fath.de/en/software/shariff-plus.html',
 
   // Type of display for the "about" page: "blank", "popup" or "self", default = "blank"
   infoDisplay: 'blank',


### PR DESCRIPTION
Add new project homepage for Shariff-Plus to docs and package info and make this the default for the "data-info-url" parameter.