### PR TITLE
Use Serbian language for facebooklike "Close" button

### DIFF
--- a/src/js/services/facebooklike.js
+++ b/src/js/services/facebooklike.js
@@ -34,7 +34,7 @@ module.exports = function(shariff) {
   case 'sk': dialogLocale = 'sk_SK'; dialogClose = 'Zatvoriť'; break
   case 'sl': dialogLocale = 'sl_SI'; dialogClose = 'Zapri'; break
   // Serbian latin is not suppported by Facebook Graph API, they only have kyrillic.
-  // case 'sr': dialogLocale = 'sr_RS'; dialogClose = 'Close'; break
+  case 'sr': dialogClose = 'Zatvori'; break
   case 'sv': dialogLocale = 'sv_SE'; dialogClose = 'Stäng'; break
   case 'tr': dialogLocale = 'tr_TR'; dialogClose = 'Kapatın'; break
   case 'zh': dialogLocale = 'zh_CN'; dialogClose = '关闭'; break


### PR DESCRIPTION
In case of Serbian (latin) language use that language for the "Close" button of the facebooklike dialog.
For the Facebook "Like" button still English is used, because Facebook only supports Serbian with kyrillic letters and not the latin transcription used by shariff and shariff-plus.