### PR TITLE
Remove case insensivity from check of the data-info-display option

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -131,13 +131,13 @@ class Shariff {
   }
 
   getInfoDisplayPopup() {
-    return (this.options.infoDisplay.toLowerCase() === 'popup')
+    return (this.options.infoDisplay === 'popup')
   }
 
   getInfoDisplayBlank() {
     return (
-      (this.options.infoDisplay.toLowerCase() !== 'popup') &&
-      (this.options.infoDisplay.toLowerCase() !== 'self')
+      (this.options.infoDisplay !== 'popup') &&
+      (this.options.infoDisplay !== 'self')
     )
   }
 


### PR DESCRIPTION
Remove the case insensivity from checking the new option to be consistent with handling of the other options.
See also [https://github.com/heiseonline/shariff/pull/272](https://github.com/heiseonline/shariff/pull/272) for (original) Shariff.