### PR TITLE
Add rel="nofollow" to all sharing buttons' links

### DIFF
--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -254,9 +254,18 @@ class Shariff {
 
       if (service.popup) {
         $shareLink.attr('data-rel', 'popup')
+        if (service.name !== 'info') {
+          $shareLink.attr('rel', 'nofollow')
+        }
       } else if (service.blank) {
         $shareLink.attr('target', '_blank')
-        $shareLink.attr('rel', 'noopener noreferrer')
+        if (service.name === 'info') {
+          $shareLink.attr('rel', 'noopener noreferrer')
+        } else {
+          $shareLink.attr('rel', 'nofollow noopener noreferrer')
+        }
+      } else if (service.name !== 'info') {
+        $shareLink.attr('rel', 'nofollow')
       }
       $shareLink.attr('title', this.getLocalized(service, 'title'))
 


### PR DESCRIPTION
Add rel="nofollow" to all sharing buttons' links, i.e. the links of all buttons except of the "info" button, for better SEO.

See pull request [https://github.com/heiseonline/shariff/pull/283](https://github.com/heiseonline/shariff/pull/283) for [heiseonline/shariff](https://github.com/heiseonline/shariff).