### PR TITLE
Change shariffplus defaults

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -90,12 +90,12 @@ Unterschiede zu Shariff sind mit (1), (2) usw. markiert und werden unterhalb der
 |------------------|--------------|---------|
 | `data-backend-url` | Pfad zum Shariff-[Backend](#backends). Der Wert `null` deaktiviert die Anzeige von Share-Counts.  | `null` |
 | `data-dialogs-media-url` (1) | Pfad zu css oder js für spezielle Dialoge wie z.B. den des Services `facebooklike` Dies muss eine absolute URL sein. Beispiel: `https://www.example.com/shariff`. Dies erlaubt es, eigene css z.B. für den Dialog `facebooklike` zu verwenden. | Pfad zum Verzeichnis, in dem Shariff-Plus installiert ist. |
-| `data-facebook-count-btn` (1) | Die Buttons(s), die den Zähler vom Backend anzeigen sollen, wenn beide Services `facebook` und `facebooklike` verwendet werden. Werte: `like`, `share`, `both`. | `both` |
+| `data-facebook-count-btn` (1) | Die Buttons(s), die den Zähler vom Backend anzeigen sollen, wenn beide Services `facebook` und `facebooklike` verwendet werden. Werte: `like`, `share`, `both`. | `like` |
 | `data-facebooklike-css` (1) | Name der CSS-Datei für den Dialog `facebooklike`. Die Datei muss im dem Ordner vorhanden sein, der mit der Option `data-dialogs-media-url` festgelegt wird. Beispiel : `data-facebooklike-css="my-styles.css"`. | `facebooklike_dlg.css` |
 | `data-facebooklike-options` (1) | Objekt mit Optionen für den Button "Gefällt mir" von Facebook, wie sie der Facebook Konfigurator für den Button liefert. Für die Verwendung im `data`-Attribut muss die Angabe Entity-enkodiert werden. Beispiel mit den Standardwerten von Facebook: `data-facebooklike-options="{&quot;width&quot;:450,&quot;layout&quot;:&quot;standard&quot;,&quot;action&quot;:&quot;like&quot;,&quot;size&quot;:&quot;large&quot;,&quot;show_faces&quot;:true,&quot;share&quot;:true,&quot;appId&quot;:&quot;99999&quot;}"` mit 99999 = Facebook `app_id`. | Siehe Beispiel, mit appId = Wert des Meta-Tags `fb:app_id` oder `null`, wenn nicht definiert. |
 | `data-flattr-category` | Kategorie für Flattr-Spende. | `null` |
 | `data-flattr-user` | Benutzer, der die Flattr-Spende erhält. | `null` |
-| `data-info-url` (2) | URL der Infoseite. | `https://www.richard-fath.de/en/software/shariff-plus.html` |
+| `data-info-url` (2) | URL der Infoseite. | `https://www.richard-fath.de/de/software/shariff-plus.html` |
 | `data-info-display` | Wie die Infoseite angezeigt wird. Werte: `blank`, `popup`, `self`. | `blank` |
 | `data-lang`      | Lokalisierung auswählen. Verfügbar: `bg`, `cs`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | Wenn `data-mail-url` ein `mailto:`-Link ist, wird dieser Wert als Mail-Body verwendet. Der Mail-Body-Text sollte den Platzhalter `{url}` enthalten. Dieser wird durch die zu teilende URL ersetzt. | siehe `data-url` |
@@ -169,8 +169,8 @@ Shariff-Plus unterstützt folgende Social-Sharing-Services:
 Zusätzlich stellt der Service `facebooklike` einen Button zur Anzeige des Buttons "Gefällt mir" von Facebook bereit.
 
 Schließlich stellt der Service `Info` einen Button zur Anzeige einer Infoseite über die Social-Sharing-Buttons bereit.
-Die URL dieser Seite kann mit einer Option festgelegt werden. Standardwert: `https://www.richard-fath.de/en/software/shariff-plus.html`, das ist die englische Version der Shariff-Plus-Projekt-Homepage.
-Die Projekt-Homepage ist auch auf [Deutsch](https://www.richard-fath.de/de/software/shariff-plus.html) und [Russisch](https://www.richard-fath.de/ru/software/shariff-plus.html) verfügbar.
+Die URL dieser Seite kann mit einer Option festgelegt werden. Standardwert: `https://www.richard-fath.de/de/software/shariff-plus.html`, das ist die deutsche Version der Shariff-Plus-Projekt-Homepage.
+Die Projekt-Homepage ist auch auf [Englisch](https://www.richard-fath.de/en/software/shariff-plus.html) und [Russisch](https://www.richard-fath.de/ru/software/shariff-plus.html) verfügbar.
 
 ## Backends
 

--- a/README.md
+++ b/README.md
@@ -90,12 +90,12 @@ Differences to Shariff are marked with (1), (2) and so on and explained below th
 |------------------|-------------|---------|
 | `data-backend-url` | The path to your Shariff backend, see below. Settings the value to `null` disables the backend feature. No counts will occur.  | `null` |
 | `data-dialogs-media-url` (1) | The path to css or js for special dialogs like e.g. the one of the `facebooklike` service. This has to be an absolute URL. Example: `https://www.example.com/shariff`. This allows to use own css e.g. for the `facebooklike` dialog. | Path to directory where Shariff-Plus is installed. |
-| `data-facebook-count-btn` (1) | The button(s) which shall show the counter from backend if both services `facebook` and `facebooklike` are used. Values: `like`, `share`, `both`. | `both` |
+| `data-facebook-count-btn` (1) | The button(s) which shall show the counter from backend if both services `facebook` and `facebooklike` are used. Values: `like`, `share`, `both`. | `like` |
 | `data-facebooklike-css` (1) | Name of the CSS file for the `facebooklike` dialog. The file has to be present in the folder specified by the `data-dialogs-media-url` option. Example : `data-facebooklike-css="my-styles.css"`. | `facebooklike_dlg.css` |
 | `data-facebooklike-options` (1) | An entity-encoded JSON string containing an object with options for the Facebook "Like" button as provided by the Facebook configurator for that button. Example with default values of Facebook: `data-facebooklike-options="{&quot;width&quot;:450,&quot;layout&quot;:&quot;standard&quot;,&quot;action&quot;:&quot;like&quot;,&quot;size&quot;:&quot;large&quot;,&quot;show_faces&quot;:true,&quot;share&quot;:true,&quot;appId&quot;:&quot;99999&quot;}"` with 99999 = Facebook `app_id`. | See example, with appId = value of the `fb:app_id` meta tag or `null` if not defined. |
 | `data-flattr-category` | Category to be used for Flattr. | `null` |
 | `data-flattr-user` | User that receives Flattr donation. | `null` |
-| `data-info-url` (2) | URL of the info page. | `https://www.richard-fath.de/en/software/shariff-plus.html` |
+| `data-info-url` (2) | URL of the info page. | `https://www.richard-fath.de/de/software/shariff-plus.html` |
 | `data-info-display` | How to display the info page. Values: `blank`, `popup`, `self`. | `blank` |
 | `data-lang`      | The localisation to use. Available: `bg`, `cs`, `de`, `en`, `es`, `fi`, `hr`, `hu`, `ja`, `ko`, `no`, `pl`, `pt`, `ro`, `ru`, `sk`, `sl`, `sr`, `sv`, `tr`, `zh` | `de` |
 | `data-mail-body` | If a `mailto:` link is used in `data-mail-url`, then this value is used as the mail body. The body text should contain the placeholder `{url}` which will be replaced with the share URL. | see `data-url`  |
@@ -170,8 +170,8 @@ Shariff-Plus supports the following social sharing services:
 In addition, the service `facebooklike` provides a button to show the Facebook "Like" button in a dialog.
 
 Finally, the service `Info` provides a button to show an info page about the social sharing buttons.
-The URL of this page can be set with an option. Default value: `https://www.richard-fath.de/en/software/shariff-plus.html`, which is the English version of the Shariff-Plus project homepage.
-The project homepage is also available in [German](https://www.richard-fath.de/de/software/shariff-plus.html) and [Russian](https://www.richard-fath.de/ru/software/shariff-plus.html).
+The URL of this page can be set with an option. Default value: `https://www.richard-fath.de/de/software/shariff-plus.html`, which is the German version of the Shariff-Plus project homepage.
+The project homepage is also available in [English](https://www.richard-fath.de/en/software/shariff-plus.html) and [Russian](https://www.richard-fath.de/ru/software/shariff-plus.html).
 
 ## Backends
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -44,12 +44,12 @@
         <dt>data-title:</dt><dd>Lorem ipsum</dd>
         <dt>data-url:</dt><dd>http://www.heise.de/ct/</dd>
         <dt>data-services:</dt><dd>[&amp;quot;whatsapp&amp;quot;,&amp;quot;facebooklike&amp;quot;,&amp;quot;facebook&amp;quot;,&amp;quot;twitter&amp;quot;,&amp;quot;googleplus&amp;quot;,&amp;quot;mail&amp;quot;,&amp;quot;info&amp;quot;]</dd>
-        <dt>data-facebook-count-btn:</dt><dd>like</dd>
+        <dt>data-facebook-count-btn:</dt><dd>both</dd>
     </dl>
     <article class="slim">
         <header>
             <h1>Lorem ipsum dolor sit amet, consectetuer adipiscing elit</h1>
-            <div data-backend-url="/backend.json" class="shariff" data-services="[&quot;whatsapp&quot;,&quot;facebooklike&quot;,&quot;facebook&quot;,&quot;twitter&quot;,&quot;googleplus&quot;,&quot;mail&quot;,&quot;info&quot;]" data-mail-url="mailto:foo@example.com" data-lang="en" data-title="Lorem ipsum" data-facebook-count-btn="like"></div>
+            <div data-backend-url="/backend.json" class="shariff" data-services="[&quot;whatsapp&quot;,&quot;facebooklike&quot;,&quot;facebook&quot;,&quot;twitter&quot;,&quot;googleplus&quot;,&quot;mail&quot;,&quot;info&quot;]" data-mail-url="mailto:foo@example.com" data-lang="en" data-title="Lorem ipsum" data-facebook-count-btn="both"></div>
             <time datetime="2014-11-13T10:45:00+02:00">13.11.2014 - 12:45 Uhr</time>
         </header>
         <p class="deck">A small river named Duden flows by their place and supplies it with the necessary regelialia. It is a paradisematic country, in which roasted parts of sentences fly into your mouth.</p>

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -20,7 +20,7 @@ const Defaults = {
   backendUrl: null,
 
   // Link to the "about" page
-  infoUrl: 'https://www.richard-fath.de/en/software/shariff-plus.html',
+  infoUrl: 'https://www.richard-fath.de/de/software/shariff-plus.html',
 
   // Type of display for the "about" page: "blank", "popup" or "self", default = "blank"
   infoDisplay: 'blank',
@@ -50,11 +50,11 @@ const Defaults = {
   referrerTrack: null,
 
   // services to be enabled in the following order
-  services: ['twitter', 'facebook', 'googleplus', 'info'],
+  services: ['twitter', 'facebooklike', 'facebook', 'googleplus', 'info'],
 
   dialogsMediaUrl: shariffPath,
 
-  facebookCountBtn: 'both',
+  facebookCountBtn: 'like',
 
   facebooklikeCss: 'facebooklike_dlg.css',
 

--- a/test/shariff-spec.js
+++ b/test/shariff-spec.js
@@ -17,7 +17,7 @@ describe('Shariff', () => {
       let s = new Shariff(div)
       assert.deepEqual(
         s.options.services,
-        ['twitter', 'facebook', 'googleplus', 'info']
+        ['twitter', 'facebooklike', 'facebook', 'googleplus', 'info']
       )
     })
   })


### PR DESCRIPTION
This PR changes following default values for options related to the `facebooklike` service:

1. When not using the `facebooklike` service, it makes no sense to use Shariff-Plus instead of Shariff. So it makes also not much sense not to have `facebooklike` in the default value for the `data-services` option. So this PR adds `facebooklike` to the default services.

2. Change the default value of option `data-facebook-count-btn` to `like` so it fits to the 1st change (both facebook buttons shown by default) and is like Facebook does when showint the "Like" button together with the "Share" button with the "Like" button plugin.

3. Adapt the demo page to the 2nd change.

4. The default value for `data-lang` is German, but the default value for `data-info-url` points to the English version of the Shariff-Plus project page. This PR makes it consistent by changing the indo url to the German version.