### PR TITLE
Add allow="encrypted-media" to iframe code of FB Like button in FacebookLike dialog

### DIFF
--- a/src/js/services/facebooklike.js
+++ b/src/js/services/facebooklike.js
@@ -76,7 +76,7 @@ module.exports = function(shariff) {
       url + '</a></div>' +
       '<div class="facebooklike"><iframe src="' + fbUrl + '" ' +
       'width="' + fblikeOptions.width + '" height="' + height + '" style="border:none;overflow:hidden" ' +
-      'scrolling="no" frameborder="0" allowTransparency="true"></iframe></div>' +
+      'scrolling="no" frameborder="0" allowTransparency="true" allow="encrypted-media"></iframe></div>' +
       '<div>' +
       '<button class="dialogbutton" onclick="self.close()">' +
       dialogClose + '</button></div>'


### PR DESCRIPTION
Update the iframe code of the Facebook Like button in the FacebookLike dialog shown by Shariff-Plus to what the Facebook code generator for the Like button currently produces.

This adds the property `allow="encrypted-media"` to the iframe, which is used by browsers supporting [Encrypted Media Extensions](https://en.wikipedia.org/wiki/Encrypted_Media_Extensions).