### PR TITLE
[3.0] Add Fontawesome v6/v7 classes

### DIFF
--- a/src/js/services/buffer.js
+++ b/src/js/services/buffer.js
@@ -33,7 +33,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'buffer',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-buffer',
     title: {
       bg: 'Сподели в buffer',

--- a/src/js/services/clipboard.js
+++ b/src/js/services/clipboard.js
@@ -42,7 +42,7 @@ export default function data(shariff) {
       zh: '',
     },
     name: 'clipboard',
-    faPrefix: 'far',
+    faPrefix: 'far fa-regular',
     faName: 'fa-copy',
     title: {
       bg: '',

--- a/src/js/services/diaspora.js
+++ b/src/js/services/diaspora.js
@@ -35,7 +35,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'diaspora',
-    faPrefix: 'fas',
+    faPrefix: 'fas fa-solid',
     faName: 'fa-asterisk',
     title: {
       bg: 'Сподели в diaspora*',

--- a/src/js/services/facebook.js
+++ b/src/js/services/facebook.js
@@ -32,7 +32,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'facebook',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-facebook-f',
     title: {
       bg: 'Сподели във Facebook',

--- a/src/js/services/facebooklike.js
+++ b/src/js/services/facebooklike.js
@@ -110,7 +110,7 @@ export default function data(shariff) {
       zh: '赞',
     },
     name: 'facebooklike',
-    faPrefix: 'fas',
+    faPrefix: 'fas fa-solid',
     faName: 'fa-thumbs-up',
     title: {
       bg: 'Харесвам/Вече не харесвам във Facebook',

--- a/src/js/services/fediverse.js
+++ b/src/js/services/fediverse.js
@@ -33,7 +33,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'fediverse',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-mastodon',
     title: {
       bg: 'Сподели в Fediverse',

--- a/src/js/services/flipboard.js
+++ b/src/js/services/flipboard.js
@@ -7,7 +7,7 @@ export default function data(shariff) {
     popup: true,
     shareText: 'flip it',
     name: 'flipboard',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-flipboard',
     title: {
       bg: 'Сподели в Flipboard',

--- a/src/js/services/info.js
+++ b/src/js/services/info.js
@@ -6,7 +6,7 @@ export default function data(shariff) {
     popup: shariff.getInfoDisplayPopup(),
     shareText: 'Info',
     name: 'info',
-    faPrefix: 'fas',
+    faPrefix: 'fas fa-solid',
     faName: 'fa-info',
     title: {
       bg: 'Повече информация',

--- a/src/js/services/linkedin.js
+++ b/src/js/services/linkedin.js
@@ -32,7 +32,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'linkedin',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-linkedin-in',
     title: {
       bg: 'Сподели в LinkedIn',

--- a/src/js/services/mail.js
+++ b/src/js/services/mail.js
@@ -23,7 +23,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'mail',
-    faPrefix: 'fas',
+    faPrefix: 'fas fa-solid',
     faName: 'fa-envelope',
     title: {
       bg: 'Изпрати по имейл',

--- a/src/js/services/pinterest.js
+++ b/src/js/services/pinterest.js
@@ -20,7 +20,7 @@ export default function data(shariff) {
     popup: true,
     shareText: 'pin it',
     name: 'pinterest',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-pinterest-p',
     title: {
       bg: 'Сподели в Pinterest',

--- a/src/js/services/pocket.js
+++ b/src/js/services/pocket.js
@@ -7,7 +7,7 @@ export default function data(shariff) {
     popup: true,
     shareText: 'Pocket',
     name: 'pocket',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-get-pocket',
     title: {
       bg: 'Запазване в Pocket',

--- a/src/js/services/print.js
+++ b/src/js/services/print.js
@@ -6,7 +6,7 @@ export default function data(shariff) {
 
   return {
     name: 'print',
-    faPrefix: 'fas',
+    faPrefix: 'fas fa-solid',
     faName: 'fa-print',
     popup: false,
     shareText: {

--- a/src/js/services/qzone.js
+++ b/src/js/services/qzone.js
@@ -35,7 +35,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'qzone',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-qq',
     title: {
       bg: 'Сподели в Qzone',

--- a/src/js/services/reddit.js
+++ b/src/js/services/reddit.js
@@ -38,7 +38,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'reddit',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-reddit-alien',
     title: {
       bg: 'Сподели в Reddit',

--- a/src/js/services/stumbleupon.js
+++ b/src/js/services/stumbleupon.js
@@ -38,7 +38,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'stumbleupon',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-stumbleupon',
     title: {
       bg: 'Сподели в Stumbleupon',

--- a/src/js/services/telegram.js
+++ b/src/js/services/telegram.js
@@ -33,7 +33,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'telegram',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-telegram',
     title: {
       bg: 'Сподели в Telegram',

--- a/src/js/services/tencent-weibo.js
+++ b/src/js/services/tencent-weibo.js
@@ -35,7 +35,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'tencent-weibo',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-tencent-weibo',
     title: {
       bg: 'Сподели в tencent weibo',

--- a/src/js/services/threema.js
+++ b/src/js/services/threema.js
@@ -35,7 +35,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'threema',
-    faPrefix: 'fas',
+    faPrefix: 'fas fa-solid',
     faName: 'fa-lock',
     title: {
       bg: 'Сподели в Threema',

--- a/src/js/services/tumblr.js
+++ b/src/js/services/tumblr.js
@@ -33,7 +33,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'tumblr',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-tumblr',
     title: {
       bg: 'Сподели в tumblr',

--- a/src/js/services/vk.js
+++ b/src/js/services/vk.js
@@ -32,7 +32,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'vk',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-vk',
     title: {
       bg: 'Сподели във VK',

--- a/src/js/services/weibo.js
+++ b/src/js/services/weibo.js
@@ -35,7 +35,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'weibo',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-weibo',
     title: {
       bg: 'Сподели в weibo',

--- a/src/js/services/whatsapp.js
+++ b/src/js/services/whatsapp.js
@@ -35,7 +35,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'whatsapp',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-whatsapp',
     title: {
       bg: 'Сподели в Whatsapp',

--- a/src/js/services/xing.js
+++ b/src/js/services/xing.js
@@ -32,7 +32,7 @@ export default function data(shariff) {
       zh: '分享',
     },
     name: 'xing',
-    faPrefix: 'fab',
+    faPrefix: 'fab fa-brands',
     faName: 'fa-xing',
     title: {
       bg: 'Сподели в XING',

--- a/src/style/shariff-layout.less
+++ b/src/style/shariff-layout.less
@@ -46,7 +46,10 @@
         }
         .fab,
         .far,
-        .fas {
+        .fas,
+        .fa-brands,
+        .fa-regular,
+        .fa-solid {
             width: 35px;
             line-height: 35px;
             text-align: center;
@@ -215,7 +218,10 @@
             }
             .fab,
             .far,
-            .fas{
+            .fas,
+            .fa-brands,
+            .fa-regular,
+            .fa-solid {
                 width: 30px;
                 line-height: 30px;
             }


### PR DESCRIPTION
This pull request (PR) adds the Fontawesome v6/v7 classes `fa-brands`, `fa-regular` and `fa-solid` classes to the services js and the `src/style/shariff-layout.less` file, keeping the old v5 classes `fab`, `far` and `fas` for backwards compatibility.

This is done for preparation of an update to Fontawesome 7, but that will need more changes as Fontawesome have dropped LESS support with v7.